### PR TITLE
Update README.md - just a . after nectar.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Once the configuration has been updated, run the build:
 For Nirin and Nectar users:
 ```
 ./scripts/nirin.sh      // nirin users
-./scripts/nectar.sh.    // nectar users
+./scripts/nectar.sh    // nectar users
 ```
 For other platform users:
 ```


### PR DESCRIPTION
Removed a . after nectar.sh in readme (would be annoying if copy-pasting commands)

A pull request is probably overkill.

